### PR TITLE
Clarify setting for "both" reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Installs and enables the Chef SNS handler.
   </tr>
   <tr>
     <td>supports</td>
-    <td>Type of Chef Handler to register as, ie <code>:report</code>, <code>:exception</code> or <code>both</code>.</td>
+    <td>Type of Chef Handler to register as, ie <code>:report</code>, <code>:exception</code> or both.</td>
     <td><code>node['chef_handler_sns']['supports']</code></td>
   </tr>
   <tr>


### PR DESCRIPTION
I misread `both` as another parameter, while this should actually read as to set both `report` and `exception` to true. Removing the <code> tag for both should clarify this.
