### PR TITLE
Bump version of chef_handler for chef-client 13 compatibility

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,9 +9,7 @@ platforms:
 - name: centos-5.11
 - name: centos-6.7
 - name: centos-7.2
-- name: debian-6.0.10
-- name: debian-7.9
-- name: debian-8.2
+- name: debian-8.7
 - name: fedora-21
 - name: fedora-22
 - name: fedora-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the `chef_handler_sns` cookbook.
 
+## v3.1.0 (2017-05-05)
+* Update chef_handler required version from ~> 1.0 to ~2.0
+ * chef_handler 2.1.1 is compatible with chef-client 13
+
 ## v3.0.0 (2016-01-01)
 
 ### Breaking Changes on v3.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This file is used to list changes made in each version of the `chef_handler_sns` cookbook.
 
-## v3.1.0 (2017-05-05)
+## v3.1.0 (unreleased)
 * Update chef_handler required version from ~> 1.0 to ~2.0
  * chef_handler 2.1.1 is compatible with chef-client 13
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -49,7 +49,7 @@ supports 'scientific'
 supports 'suse'
 supports 'ubuntu'
 
-depends 'chef_handler', '~> 1.0'
+depends 'chef_handler', '~> 2.0'
 
 recipe 'chef_handler_sns::default', 'Installs and loads the Chef SNS Handler.'
 


### PR DESCRIPTION
According to https://github.com/chef-cookbooks/chef_handler/blob/master/CHANGELOG.md version 2.1.1 of chef_handler is compatible with chef-client 13. I bumped the chef_handler and the tests seems to pass except older debian versions